### PR TITLE
update paths-for-growth.rst

### DIFF
--- a/src/paths-for-growth.rst
+++ b/src/paths-for-growth.rst
@@ -116,7 +116,7 @@ In starting or joining a group, you can share your vision, ideas for possible so
 One possible path is to start a community group and invite people from outside the W3C who care about the domain you're exploring to give feedback on their pain points where that domain intersects with web.
 Your community group can then take those pain points, synthesize them into use cases, and bring them to existing working groups to include in their standardization work.
 
-In 2011, the Web Games Community Group did just this, producing a set of use cases and bringing them to various W3C working groups to be addressed.
+In 2011, the Games Community Group did just this, producing a set of use cases and bringing them to various W3C working groups to be addressed.
 By 2019, nearly all of the pain points the CG identified for web games developers had been addressed.
 You can read one of the `initial Games CG reports from 2011 <https://docs.google.com/a/bocoup.com/document/pub?id=1fs1hpZvP05ViEWtaLSmNQUV_PW2jCWS5Oe2GAdBKgl0>`_.
 


### PR DESCRIPTION
fixes #12, #26

Related, this made me think about how we want to display / share additional resources and links that may not make sense to go inline with the text, for example links to the W3C's chair role definition etc.