### PR TITLE
Remove jekyll processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
       - attach_workspace:
           at: build
       - run:
+          name: Disable jekyll builds
+          command: touch build/html/.nojekyll
+      - run:
           name: Install and configure dependencies
           command: |
             npm install -g --silent gh-pages@2.0.1


### PR DESCRIPTION
I think the css is being removed because the folder starts with "_" and that is used by some automatic circleci jekyll processing.